### PR TITLE
Safeguard Against Negative FRP

### DIFF
--- a/src/qfed/frp.py
+++ b/src/qfed/frp.py
@@ -268,7 +268,7 @@ class GriddedFRP:
         lon = self._fp_reader.get_fire_longitude(fire_product_file)
         lat = self._fp_reader.get_fire_latitude(fire_product_file)
         frp = self._fp_reader.get_fire_frp(fire_product_file)
-
+        frp[frp < 0]=0
         line = self._fp_reader.get_fire_line(fire_product_file)
         sample = self._fp_reader.get_fire_sample(fire_product_file)
         area = self._fp_reader.get_fire_pixel_area(fire_product_file)

--- a/src/qfed_l3b.py
+++ b/src/qfed_l3b.py
@@ -291,7 +291,7 @@ def main():
         os.path.dirname(sys.argv[0]), 'emission_factors.yaml'
     )
 
-    species = ('co2', 'oc', 'so2', 'nh3', 'bc')
+    species = ('co2', 'oc', 'so2', 'nh3', 'bc', 'co')
 
     start, end = cli_utils.get_entire_time_interval(args)
     intervals = cli_utils.get_timestamped_time_intervals(start, end, timedelta(hours=24))


### PR DESCRIPTION
In rare cases, the granules from VIIRS have negative values of FRP. To prevent this from being included in the gridded FRP (and causing ridiculous emissions), a line was added to set negative values to zero. Since this changes the FRP and emissions in these rare cases, I have labeled it as non-zero diff. It is zero diff the vast majority of the time.

Also included here, is the addition of carbon monoxide in the driver code, qfed_l3b.py, so that CO emissions are written out.