### PR TITLE
uptick version and update contact info for science quality 2.6r1

### DIFF
--- a/src/qfed/emissions.py
+++ b/src/qfed/emissions.py
@@ -524,7 +524,7 @@ class Emissions(object):
            f.Conventions = 'COARDS'
            f.Source      = 'NASA/GSFC, Global Modeling and Assimilation Office'
            f.Title       = 'QFED Level3a v{version:s} Gridded FRP Estimates'.format(version=__version__)
-           f.Contact     = 'Anton Darmenov <anton.s.darmenov@nasa.gov>'
+           f.Contact     = 'https://gmao.gsfc.nasa.gov/'
            f.Version     = str(__version__)
            f.Processed   = str(datetime.now())
            f.History     = '' 

--- a/src/qfed/mxd14_l3.py
+++ b/src/qfed/mxd14_l3.py
@@ -427,7 +427,7 @@ class MxD14_L3(object):
        f.Conventions = 'COARDS'
        f.Source      = 'NASA/GSFC, Global Modeling and Assimilation Office'
        f.Title       = 'QFED Level3a v{version:s} Gridded FRP Estimates'.format(version=__version__)
-       f.Contact     = 'Anton Darmenov <anton.s.darmenov@nasa.gov>'
+       f.Contact     = 'https://gmao.gsfc.nasa.gov/'
        f.Version     = str(__version__)
        f.Processed   = str(datetime.now())
        f.History     = '' 

--- a/src/qfed/version.py
+++ b/src/qfed/version.py
@@ -1,2 +1,2 @@
-__version__ = '2.5.r1-geos-esm'
+__version__ = '2.6.r2-geos-esm'
 __tag__     = 'n/a'

--- a/src/qfed_l3a.py
+++ b/src/qfed_l3a.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
 #       ------------------
         for MxD14 in Products:
 
-            Path = os.path.join(args.level2_dir, MxD14, '%04d'%d.year, '%03d'%doy)
+            Path = os.path.join(args.level2_dir, MxD14 + '_L2', '%04d'%d.year, '%03d'%doy)
 
 #           Do the gridding for this product
 #           --------------------------------


### PR DESCRIPTION
-This is non-zero diff from SLES12 to SLES15 providing the output files are not compressed (confirmed by Rob L. after extensive testing by the ops team.
-The version was upticked to 2.6r2 as this code is being used to reprocess the science quality files for 2015-2018.
-The contact info in the netcdf files was changed to the GMAO website to match what is used for other GMAO product.
-The filepath structure is slightly different for the files residing on /css, requiring a minor change to qfed_l3a.py.

