### PR TITLE
GDAL-compatible metadata + bugfix

### DIFF
--- a/src/qfed/emissions.py
+++ b/src/qfed/emissions.py
@@ -419,7 +419,7 @@ class Emissions:
             begin_date = int(self.time.strftime('%Y%m%d'))
             begin_time = int(self.time.strftime('%H%M%S'))
             v.long_name = 'time'
-            v.standard_name = 'latitude'
+            v.standard_name = 'time'
             v.units = 'minutes since {:%Y-%m-%d %H:%M:%S}'.format(self.time)
             v.begin_date = np.array(begin_date, dtype=np.int32)
             v.begin_time = np.array(begin_time, dtype=np.int32)

--- a/src/qfed/emissions.py
+++ b/src/qfed/emissions.py
@@ -372,6 +372,9 @@ class Emissions:
             f.createVariable('lat', 'f8', dimensions='lat')
             f.createVariable('time', 'i4', dimensions='time')
 
+            # spatial reference variable (as needed by GDAL)
+            f.createVariable('spatial_ref', 'i8')
+
             # data variables
             for v in v_meta_data.values():
                 f.createVariable(
@@ -388,12 +391,29 @@ class Emissions:
             v.standard_name = 'longitude'
             v.units = 'degrees_east'
             v.comment = 'center_of_cell'
+            v.axis = 'X'
 
             v = f.variables['lat']
             v.long_name = 'latitude'
             v.standard_name = 'latitude'
             v.units = 'degrees_north'
             v.comment = 'center_of_cell'
+            v.axis = 'Y'
+
+            # Spatial reference variable attributes (as needed by GDAL)
+            # These are the default values for EPSG 4326 (lat-lon with WGS84 ellipsoid)
+            v = f.variables['spatial_ref']
+            v.crs_wkt = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]"
+            v.semi_major_axis = 6378137.
+            v.semi_minor_axis = 6356752.31424518
+            v.inverse_flattening = 298.257223563
+            v.reference_ellipsoid_name = "WGS 84"
+            v.longitude_of_prime_meridian = 0.
+            v.prime_meridian_name = "Greenwich"
+            v.geographic_crs_name = "WGS 84"
+            v.horizontal_datum_name = "World Geodetic System 1984"
+            v.grid_mapping_name = "latitude_longitude"
+            v.spatial_ref = v.crs_wkt
 
             v = f.variables['time']
             begin_date = int(self.time.strftime('%Y%m%d'))
@@ -413,6 +433,7 @@ class Emissions:
                 v.fmissing_value = np.array(fill_value, np.float32)
                 v.vmin = np.array(fill_value, np.float32)
                 v.vmax = np.array(fill_value, np.float32)
+                v.coordinates = "spatial_ref"  # Needed for GDAL
 
             # coordinate variables - data
             f.variables['time'][:] = np.array((0,))


### PR DESCRIPTION
Adds additional metadata to make the files more readily compatible with geospatial software based on GDAL (i.e., most desktop GIS software).

Strictly speaking, I think this metadata is somewhat optional. In the absence of coordinate information, GDAL will assume a lot of these things already. But, I think it may be better to be explicit about our coordinate system and slightly improve compatibility.  

This essentially mirrors what happens when you run `rioxarray`'s `write_crs`, `set_spatial_dims`, and `write_coordinate_system` methods, which make an Xarray (NetCDF-like) dataset GDAL-compatible.

https://corteva.github.io/rioxarray/stable/getting_started/crs_management.html

Additional information on GDAL's NetCDF driver: https://gdal.org/en/stable/drivers/raster/netcdf.html

In doing this, I also noticed a small bug with the `standard_name` for the `time` attribute was set to `latitude`.