### PR TITLE
Update cmake in cmake_it and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,24 @@ mepo clone git@github.com:GEOS-ESM/QFED.git
 This will clone the main branch. Use -b to clone a specific branch.
 
 ### Build and Install
+
+#### Using `cmake_it`
+
+`cmake_it` is a script that "automates" the CMake build process by essentially
+running the CMake commands seen in the next section.
+
 ```
 cd QFED
 source @env/g5_modules.sh
 ./cmake_it
+```
+
+#### Using CMake Directly
+
+```
+cd QFED
+source @env/g5_modules.sh
+cmake -B build -S . --install-prefix=$(pwd)/install
 cmake --build build --target install -j 6
 ```
 

--- a/cmake_it
+++ b/cmake_it
@@ -4,9 +4,5 @@
 #
 
 ###source @env/g5_modules # to be sure
-mkdir -p build
-cd build
-##cmake .. -DBASEDIR=$BASEDIR/`uname -s` \
-cmake .. -DCMAKE_Fortran_COMPILER=ifort \
-         -DCMAKE_INSTALL_PREFIX=../install # -DCMAKE_BUILD_TYPE=Debug
-      
+cmake -B build -S . --install-prefix `pwd`/install # -DCMAKE_BUILD_TYPE=Debug
+cmake --build build --target install -j 6


### PR DESCRIPTION
In talking with @AgilentGCMS, I noticed that the CMake in `cmake_it` and the README was a bit old.

So this PR does two things:

1. Updates `cmake_it` to just "do everything" so it runs cmake, builds, and installs
2. Update `README.md` to have the usual CMake by hand build instructions.