### PR TITLE
Peat + Parallelize Emissions by Species

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added scripts to generate the IGBP+ for land surface type updating 
 - Added `gen_global_MODIS_IGBP.py`, `gen_global_volcano_source.py`, `gen_global_gasflaring_source.py`, `lib_IGBP_plus.py` to `dev_toolbox` [25-11-17]
+- Functionality for peat, but this is zero-diff if no peat file is given
 ### Changed
 - Update `components.yaml` to match current versions from GEOSgcm `main`
 - Renamed folder `emissionstuning` to `dev_toolbox` [25-11-17]
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Processing of FRP granules by running in parallel within the ingest function of frp.py
 - Values in alpha_factor.yaml to represent the latest FRP from VJ1 scaled to GFED5, with the other satellites anchored to VJ1
 - Biomes (now includes savannah, grassland, tropical forest, temperate forest, boreal forest, agriculture)
+- emissions.py to precompute fields used for all emissions calculations and then calculate each species in parallel
 ### Removed
 ### Deprecated
 

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,5 +1,5 @@
 define:
-    qfed_base_dir: &qfed_base_dir /discover/nobackup/projects/gmao/geos_aerosols/acollow/QFED/
+    qfed_base_dir: &qfed_base_dir /discover/nobackup/projects/gmao/geos_aerosols/acollow/QFED/peat
 
 qfed:
     scaling:
@@ -57,5 +57,6 @@ qfed:
                 file: /css/viirs/data/Level2/VJ214IMG/{0:%Y}/{0:%j}/VJ214IMG.A{0:%Y%j}.{0:%H%M}.002.*.nc
 
         igbp: /discover/nobackup/projects/gmao/geos_aerosols/shared/emissions/IGBP+/GL_IGBP_PLUS.MODIS.{0:%Y}.nc
+        peat: /discover/nobackup/projects/gmao/geos_aerosols/shared/emissions/IGBP+/GL_PEAT_GPA22.nc
         watermask: /discover/nobackup/projects/gmao/geos_aerosols/shared/emissions/watermask/watermask-700m.no_coast.nc4
         FRPcapping: False

--- a/src/qfed/emissions.py
+++ b/src/qfed/emissions.py
@@ -8,6 +8,7 @@ import subprocess
 import logging
 import yaml
 from datetime import date, datetime, timedelta
+import concurrent.futures
 
 import numpy as np
 import netCDF4 as nc
@@ -204,11 +205,36 @@ class Emissions:
         i = A_l > 0
         j = (A_l + A_c) > 0
 
-        E = {}
-        E_ = {}
-        for s in species:
-            E[s] = {bb: np.zeros((self.im, self.jm)) for bb in self.biomass_burning}
-            E_[s] = {bb: np.zeros((self.im, self.jm)) for bb in self.biomass_burning}
+        # --- PRECOMPUTE CONSTANTS AND WEIGHTS TO AVOID REPEATED ARRAY ALLOCATIONS ---
+        decay_factor = np.exp(-dt/tau)
+
+        weight_E_b = np.zeros((self.im, self.jm), dtype=np.float32)
+        weight_E_b_ = np.zeros((self.im, self.jm), dtype=np.float32)
+        
+        # Precompute denominator and ratio for 'default' / 'sequential' method
+        denom_j = A_o[j] + A_c[j]
+        ratio_j = A_c[j] / (A_l[j] + A_c[j])
+        weight_E_b[j] = (1.0 + ratio_j) / denom_j
+        weight_E_b_[j] = ratio_j / denom_j
+
+        # Precompute weights for other methods
+        weight_seq_zero = np.zeros((self.im, self.jm), dtype=np.float32)
+        weight_seq_zero[i] = (1.0 + A_c[i] / (A_l[i] + A_c[i])) / (A_o[i] + A_c[i])
+
+        weight_nofires = np.zeros((self.im, self.jm), dtype=np.float32)
+        weight_nofires[i] = 1.0 / (A_o[i] + A_c[i])
+
+        weight_similarity = np.zeros((self.im, self.jm), dtype=np.float32)
+        weight_similarity[i] = (1.0 / A_l[i]) * ((A_l[i] + A_c[i]) / (A_o[i] + A_c[i]))
+
+        weight_sim_qfed22 = np.zeros((self.im, self.jm), dtype=np.float32)
+        weight_sim_qfed22[i] = 1.0 / A_o[i]
+        # ----------------------------------------------------------------------------
+
+        # Helper function to process a single species in parallel
+        def process_species(s):
+            e_s = {bb: np.zeros((self.im, self.jm), dtype=np.float32) for bb in self.biomass_burning}
+            e_s_ = {bb: np.zeros((self.im, self.jm), dtype=np.float32) for bb in self.biomass_burning}
 
             for p in self.platform:
                 S_f = self.satellite_factor(p)
@@ -220,35 +246,48 @@ class Emissions:
                     # TODO: A_f should be a dict.
                     B_f, eB_f = self.emission_factor(s, bb)
                     A_f = self.effective_combustion_rate(p, s, bb)
-                    E[s][bb][:, :] += units_factor * A_f * S_f * B_f * FRP[bb]
-                    E_[s][bb][:, :] += units_factor * A_f * S_f * B_f * F[bb] * A_
+                    
+                    # Precalculate the scalar multiplier to avoid repeated array-scalar multiplication
+                    scalar_mult = units_factor * A_f * S_f * B_f
+                    
+                    e_s[bb][:, :] += scalar_mult * FRP[bb]
+                    e_s_[bb][:, :] += scalar_mult * F[bb] * A_
 
             for bb in self.biomass_burning:
-                E_b = E[s][bb][:, :]
-                E_b_ = E_[s][bb][:, :] * np.exp(-dt/tau)
+                E_b = e_s[bb][:, :]
+                E_b_ = e_s_[bb][:, :] * decay_factor
 
                 if (method == 'default') or (method == 'sequential'):
-                    E_b[j] = ( (E_b[j]  / (A_o[j] + A_c[j])) * (1 + A_c[j] / (A_l[j] + A_c[j])) +
-                               (E_b_[j] / (A_o[j] + A_c[j])) * (    A_c[j] / (A_l[j] + A_c[j])) )
+                    E_b[j] = E_b[j] * weight_E_b[j] + E_b_[j] * weight_E_b_[j]
 
-                if method == 'sequential-zero':
-                    E_b[i] = (
-                        E_b[i] / (A_o[i] + A_c[i]) * (1.0 + A_c[i] / (A_l[i] + A_c[i]))
-                    )
+                elif method == 'sequential-zero':
+                    E_b[i] = E_b[i] * weight_seq_zero[i]
 
-                if method == 'nofires':
-                    E_b[i] = E_b[i] / (A_o[i] + A_c[i])
+                elif method == 'nofires':
+                    E_b[i] = E_b[i] * weight_nofires[i]
 
-                if method == 'similarity':
-                    E_b[i] = E_b[i] / A_l[i] * ((A_l[i] + A_c[i]) / (A_o[i] + A_c[i]))
+                elif method == 'similarity':
+                    E_b[i] = E_b[i] * weight_similarity[i]
 
-                if method == 'similarity_qfed-2.2':
-                    E_b[i] = E_b[i] / A_o[i]
+                elif method == 'similarity_qfed-2.2':
+                    E_b[i] = E_b[i] * weight_sim_qfed22[i]
+
+            return s, e_s, e_s_
+
+        E = {}
+        E_ = {}
+        
+        # Execute species processing in parallel using threads
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            future_to_species = {executor.submit(process_species, s): s for s in species}
+            for future in concurrent.futures.as_completed(future_to_species):
+                s, e_s, e_s_ = future.result()
+                E[s] = e_s
+                E_[s] = e_s_
 
         self.estimate = E
         
         # Update forecast of FRP density based on current emissions
-
 
         # Select first species to use for calculating forecast
         s = list(species)[0]

--- a/src/qfed/fire.py
+++ b/src/qfed/fire.py
@@ -73,5 +73,10 @@ BIOMASS_BURNING = (
         type=FireType.AGRICULTURAL,
         vegetation=VegetationCategory.AGRICULTURAL,
     ),
+     Fire(
+        description='Peatland',
+        type=FireType.PEATLAND,
+        vegetation=VegetationCategory.PEATLAND,
+    ),   
 )
 

--- a/src/qfed/frp.py
+++ b/src/qfed/frp.py
@@ -163,7 +163,7 @@ def _process_granule(
     # ---- watermask (shared copy) ----------------------------------------
     global _SHARED_WATERMASK
     watermask = _SHARED_WATERMASK
-
+    
     # ---- classification -------------------------------------------------
     # set_auxiliary and read both mutate cp_reader, but each process
     # owns its own instance so there is no cross-worker interference.
@@ -338,12 +338,14 @@ class GriddedFRP:
         igbp,                   # IGBPNetCDF instance or path string
         watermask_file: str = '',
         max_workers: int = 4,
+        peat_file: str | None = None,
     ):
         self._grid           = grid
         self._finder         = finder
         self.sat             = sat
         self._watermask_file = watermask_file
         self._max_workers    = max_workers
+        self._peat_file      = peat_file
 
         # Accept either an IGBPNetCDF instance or a raw path string.
         # Workers always receive the path so they can build their own
@@ -404,7 +406,7 @@ class GriddedFRP:
         if _SHARED_IGBP is None:
             logging.info(f"Pre-loading IGBP data into shared memory from {self._igbp_file}")
             from qfed.vegetation import IGBPNetCDF
-            _SHARED_IGBP = IGBPNetCDF(self._igbp_file)
+            _SHARED_IGBP = IGBPNetCDF(self._igbp_file, peat_file=self._peat_file)
             
         # Load the watermask data into memory ONCE in the main process
         if _SHARED_WATERMASK is None:
@@ -644,6 +646,7 @@ class GriddedFRP:
             'sv': 'Fire Radiative Power (Savanna)',
             'gl': 'Fire Radiative Power (Grasslands)',
             'ag': 'Fire Radiative Power (Agricultural)',
+            'pt': 'Fire Radiative Power (Peat)',
         }
 
         v_meta = {**area_meta}

--- a/src/qfed/vegetation.py
+++ b/src/qfed/vegetation.py
@@ -53,7 +53,8 @@ class IGBPNetCDF():
                  static_heat=False,
                  gasflaring=False, 
                  volcano=False, 
-                 static_heat_threshold=16):
+                 static_heat_threshold=16,
+                 peat_file=None):
         """
         Parameters
         ----------
@@ -71,17 +72,22 @@ class IGBPNetCDF():
             Whether to read volcano mask from the IGBP+ file.
         static_heat_threshold : int, optional
             Minimum value in static_heat_mask to qualify as a static source.
+        peat_file : str or None, optional
+            Path to the GL_PEAT_GPA22 NetCDF file.  When None (default),
+            peat reclassification is skipped entirely.
         """
 
         self.file                = file
         self.nonVeg              = nonVeg
         self.drops               = drops
+        self.peat_file           = peat_file
 
         self._open_igbp()
         self._open_igbp_plus(static_heat=static_heat,
                              gasflaring=gasflaring,
                              volcano=volcano,
                              static_heat_threshold=static_heat_threshold)
+        self._open_peat()
 
 
     # ------------------------------------------------------------------
@@ -156,6 +162,54 @@ class IGBPNetCDF():
             ncid.close()
 
 
+    def _open_peat(self):
+        """
+        Read the peat_mask variable from the GL_PEAT_GPA22 NetCDF file.
+
+        Sets the following instance attributes (all None when peat_file
+        is not supplied):
+            peat_mask      : 2-D uint8 array  (northing × easting)
+                             0 = non-peat land
+                             1 = peat-dominated (continuous)
+                             2 = peat-in-soil-mosaic
+                           255 = no data / fill
+            x_peat_min     : minimum easting  (metres, sinusoidal)
+            dx_peat        : easting  pixel size (metres)
+            y_peat_max     : maximum northing (metres, sinusoidal)
+            dy_peat        : northing pixel size (metres)
+        """
+
+        # Initialise to None so downstream code can test `if self.peat_mask is not None`
+        self.peat_mask  = None
+        self.x_peat_min = None
+        self.dx_peat    = None
+        self.y_peat_max = None
+        self.dy_peat    = None
+
+        if self.peat_file is None:
+            return
+
+        logging.info(f"Reading peat file {self.peat_file}")
+
+        ncid = Dataset(self.peat_file, 'r')
+        ncid.set_auto_mask(False)
+
+        try:
+            self.peat_mask = ncid['peat_mask'][:]          # ubyte, fill=255
+
+            easting  = ncid['easting'][:]
+            northing = ncid['northing'][:]
+
+            self.x_peat_min = np.min(easting)
+            self.dx_peat    = abs(np.mean(np.diff(easting)))
+
+            self.y_peat_max = np.max(northing)
+            self.dy_peat    = abs(np.mean(np.diff(northing)))
+
+        finally:
+            ncid.close()
+
+
     @staticmethod
     def _geog_to_sinu(lat, lon):
         """
@@ -221,6 +275,38 @@ class IGBPNetCDF():
         iy = np.clip(iy, 0, ny - 1)
 
         return self.plus_mask[iy, ix]
+
+
+    def getPeatClassification(self, lat, lon):
+        """
+        Return the raw peat_mask value at given lat/lon.
+
+        Returns
+        -------
+        numpy array of uint8
+            0   : non-peat land
+            1   : peat-dominated (continuous)
+            2   : peat-in-soil-mosaic
+            255 : no-data / fill  (treat as non-peat in downstream logic)
+
+        Returns an array of zeros (non-peat) for all points when no
+        peat file was loaded.
+        """
+        lat = np.asarray(lat)
+        lon = np.asarray(lon)
+
+        if self.peat_mask is None:
+            return np.zeros(lat.shape, dtype=np.uint8)
+
+        ix, iy = self._index_from_latlon(lat, lon,
+                                         self.dx_peat, self.dy_peat,
+                                         self.x_peat_min, self.y_peat_max)
+
+        ny, nx = self.peat_mask.shape
+        ix = np.clip(ix, 0, nx - 1)
+        iy = np.clip(iy, 0, ny - 1)
+
+        return self.peat_mask[iy, ix]
 
 
     def getSimpleVeg(self, lat, lon):
@@ -293,6 +379,22 @@ class IGBPNetCDF():
         veg[mask_crop]     = AGRICULTURAL
         veg[mask_plus]     = igbp_plus[mask_plus]
 
+        # --- peat override ---
+        # Reclassify boreal/temperate forest, savanna, and grassland
+        # pixels to PEAT (6) when the GPA22
+        # peat_mask indicates class 1 (peat-dominated / continuous peatland).
+        if self.peat_mask is not None:
+            peat_raw = self.getPeatClassification(lat, lon)
+
+            mask_peat_eligible = (
+                (veg == SAVANNA) |                         # savanna
+                (veg == GRASSLAND)                         # grassland
+            )
+
+            mask_peat = mask_peat_eligible & (peat_raw == 1)
+
+            veg[mask_peat] = PEATLAND
+
         return veg
 
 
@@ -349,7 +451,7 @@ class IGBPNetCDF():
 #                       static_heat_threshold = 16)
 #     
 #     # for 2024, 
-#     # Point 1 volvano; Point 2 gas flaring; Point 3 static source; 
+#     # Point 1 volcano; Point 2 gas flaring; Point 3 static source; 
 #     # point 4 Evergreen Broadleaf Forests in Amazon
 #     # point 5, Desert in Sahara; 
 #     # point 6, Deciduous Needleleaf Forests in Siberia

--- a/src/qfed_l3a.py
+++ b/src/qfed_l3a.py
@@ -134,6 +134,7 @@ def process(
     output,
     obs_system,
     igbp_template,
+    peat_file,
     version,
     watermask_file,
     compress,
@@ -185,6 +186,7 @@ def process(
     igbp_path = igbp_template.format(t_start)
     logging.info(f"Using IGBP file: {igbp_path}")
 
+
     for satellite in obs_system.keys():
 
         platform = Satellite(satellite)
@@ -213,6 +215,7 @@ def process(
         fp_reader = fire_products.create(platform)
         cp_reader = classification_products.create(platform)
 
+
         # Generate gridded FRP and areas.
         # Pass igbp_path and watermask_file as strings — workers load
         # and cache their own instances, avoiding large array pickling.
@@ -225,6 +228,7 @@ def process(
             cp_reader,
             igbp_path,
             watermask_file=watermask_file,
+            peat_file=peat_file,
             max_workers=max_workers,
         )
         frp.ingest(t_start, t_end)
@@ -279,6 +283,7 @@ def main():
 
     # Keep as a raw template string; formatted with t_start inside process()
     igbp_template = config['qfed']['with']['igbp']
+    peat_file = config['qfed']['with'].get('peat', None) 
 
     obs = {platform: config['qfed']['with'][platform] for platform in args.obs}
 
@@ -311,6 +316,7 @@ def main():
             output,
             obs,
             igbp_template,
+            peat_file,
             version,
             watermask_file,
             args.compress,


### PR DESCRIPTION
Adds back in the peat functionality. Note this will be zero-diff if no file is given in config.yaml.

Sped up emissions.py by computing emissions for each species in parallel.